### PR TITLE
added parsing multi path for "sources" parameter

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -61,7 +61,8 @@ def get_args():
         args.extend(additional_args)
 
     if INPUT_SOURCES != "":
-        args.append(INPUT_SOURCES)
+        sources = filter(lambda arg: arg != "", INPUT_SOURCES.split(" "))
+        args.extend(sources)
 
     return args
 


### PR DESCRIPTION
Action functionality was extended to allow passing multiple paths using "sources" parameter for running cppcheck

example:

``` yaml
      - name: Run cppcheck-annotation-action 
        uses: Konstantin343/cppcheck-annotation-action@v1.1
        with:
          sources: ./src ./test/unit_tests
```

         